### PR TITLE
8 instance name error

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,5 +57,5 @@ if __name__ == "__main__":
     if parsed_args.production:
         segmenter_app.serve_production()
     else:
-        app.logger.setLevel(logging.DEBUG)
+        segmenter.logger.setLevel(logging.DEBUG)
         segmenter_app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-clams-python==1.0.9
+clams-python==1.2.1
 inaSpeechSegmenter==0.7.6
 tensorflow==2.*


### PR DESCRIPTION
1. fix the naming error of `segmenter` in `app.py` line 60
2. update `clams-python` to `1.2.1` in `requirements.txt`
